### PR TITLE
fix: continue fix Obsidian v.15.*

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -49,6 +49,7 @@ export default class VimIMSwitchPlugin extends Plugin {
 				if (this.cmEditor) {
 					// default is normal mode, try to deactivate the IM.
 					await this.deactivateIM();
+					this.cmEditor.off("vim-mode-change", this.onVimModeChange);
 					this.cmEditor.on("vim-mode-change", this.onVimModeChange);
 				}
 		});
@@ -66,6 +67,7 @@ export default class VimIMSwitchPlugin extends Plugin {
 				if (this.cmEditor) {
 					// default is normal mode, try to deactivate the IM.
 					await this.deactivateIM();
+					this.cmEditor.off("vim-mode-change", this.onVimModeChange);
 					this.cmEditor.on("vim-mode-change", this.onVimModeChange);
 				}
 			}


### PR DESCRIPTION
@yuanotes , I find a bug by registering callback often. Obsidian does reuse old editor sometimes, if that case, current code will register callback multiple times and when vim mode changes, the callback will be called multiple times.

If the callback being registered for 50 times, the Obsidian will slow down a lot.

I quickly fix this bug, but I don't suggest to merge the PR right now. Let me test the plugin for like 1 month. I send the PR just to avoid wasting your time in case you are confused by this bug.